### PR TITLE
Test seq-format-validation workflow on GEL CloudOS

### DIFF
--- a/validate-bam.wdl
+++ b/validate-bam.wdl
@@ -28,7 +28,7 @@ version 1.0
 # WORKFLOW DEFINITION
 workflow ValidateBamsWf {
   input {
-    Array[File] bam_array 
+    Array[File] bam_array = ["s3://lifebit-featured-datasets/IGV/crg-covid/BAM/8F6N9_Korea_IVT.Wuhan_Hu_1_NanoPreprocess_alignment_Guppy3.1.5_Minimap2Default.minimap2.sorted.05.bam"]
     String gatk_docker = "broadinstitute/gatk:latest"
     String gatk_path = "/gatk/gatk"
   }

--- a/validate-bam.wdl
+++ b/validate-bam.wdl
@@ -28,8 +28,10 @@ version 1.0
 # WORKFLOW DEFINITION
 workflow ValidateBamsWf {
   input {
-    #Array[File] bam_array = ["s3://lifebit-user-data-50778203-8300-4b61-8caf-0795a091ed3f/deploit/teams/5fc3e61799766d00247f4936/users/5ffc7039789f8601c0ced817/dataset/60c86d19a4146301a5229e04/uploaded.bam"]
-    Array[File] bam_array = ["s3://lifebit-user-data-f0d08d30-1ff5-4d53-9128-9140f5e050ec/deploit/teams/5fc3e61799766d00247f4936/users/60c77bf4ec129e01a5a37e74/dataset/60c86d19a4146301a5229e04/test_test2.bam"]
+    #Array[File] bam_array = ["/Users/eva/git/fix/test/PRJNA608224_Australia_Infected.Wuhan_Hu_1.Spliced_Nanopreprocess_alignment_SARS-COV2_pass.minimap2.sorted.bam"]
+    Array[File] bam_array = ["s3://lifebit-user-data-50778203-8300-4b61-8caf-0795a091ed3f/deploit/teams/5fc3e61799766d00247f4936/users/5ffc7039789f8601c0ced817/dataset/60c86d19a4146301a5229e04/uploaded.bam"]
+    #Array[File] bam_array = ["/Users/eva/git/fix/test/test_test2.bam"]
+    #Array[File] bam_array = ["s3://lifebit-user-data-f0d08d30-1ff5-4d53-9128-9140f5e050ec/deploit/teams/5fc3e61799766d00247f4936/users/60c77bf4ec129e01a5a37e74/dataset/60c86d19a4146301a5229e04/test_test2.bam"]
     String gatk_docker = "broadinstitute/gatk:latest"
     String gatk_path = "/gatk/gatk"
   }
@@ -79,6 +81,8 @@ task ValidateBAM {
   command {
     ${gatk_path} \
       ValidateSamFile \
+      --IGNORE_WARNINGS true \
+      --IGNORE MISSING_READ_GROUP \
       --INPUT ${input_bam} \
       --OUTPUT ${output_name} \
       --MODE ${default="SUMMARY" validation_mode}

--- a/validate-bam.wdl
+++ b/validate-bam.wdl
@@ -28,7 +28,7 @@ version 1.0
 # WORKFLOW DEFINITION
 workflow ValidateBamsWf {
   input {
-    Array[File] bam_array = ["s3://lifebit-featured-datasets/IGV/crg-covid/BAM/8F6N9_Korea_IVT.Wuhan_Hu_1_NanoPreprocess_alignment_Guppy3.1.5_Minimap2Default.minimap2.sorted.05.bam"]
+    Array[File] bam_array = ["s3://lifebit-user-data-50778203-8300-4b61-8caf-0795a091ed3f/deploit/teams/5fc3e61799766d00247f4936/users/5ffc7039789f8601c0ced817/dataset/60c86d19a4146301a5229e04/uploaded.bam"]
     String gatk_docker = "broadinstitute/gatk:latest"
     String gatk_path = "/gatk/gatk"
   }

--- a/validate-bam.wdl
+++ b/validate-bam.wdl
@@ -28,7 +28,8 @@ version 1.0
 # WORKFLOW DEFINITION
 workflow ValidateBamsWf {
   input {
-    Array[File] bam_array = ["s3://lifebit-user-data-50778203-8300-4b61-8caf-0795a091ed3f/deploit/teams/5fc3e61799766d00247f4936/users/5ffc7039789f8601c0ced817/dataset/60c86d19a4146301a5229e04/uploaded.bam"]
+    #Array[File] bam_array = ["s3://lifebit-user-data-50778203-8300-4b61-8caf-0795a091ed3f/deploit/teams/5fc3e61799766d00247f4936/users/5ffc7039789f8601c0ced817/dataset/60c86d19a4146301a5229e04/uploaded.bam"]
+    Array[File] bam_array = ["s3://lifebit-user-data-f0d08d30-1ff5-4d53-9128-9140f5e050ec/deploit/teams/5fc3e61799766d00247f4936/users/60c77bf4ec129e01a5a37e74/dataset/60c86d19a4146301a5229e04/test_test2.bam"]
     String gatk_docker = "broadinstitute/gatk:latest"
     String gatk_path = "/gatk/gatk"
   }

--- a/validate-bam.wdl
+++ b/validate-bam.wdl
@@ -28,10 +28,7 @@ version 1.0
 # WORKFLOW DEFINITION
 workflow ValidateBamsWf {
   input {
-    #Array[File] bam_array = ["/Users/eva/git/fix/test/PRJNA608224_Australia_Infected.Wuhan_Hu_1.Spliced_Nanopreprocess_alignment_SARS-COV2_pass.minimap2.sorted.bam"]
     Array[File] bam_array = ["s3://lifebit-user-data-50778203-8300-4b61-8caf-0795a091ed3f/deploit/teams/5fc3e61799766d00247f4936/users/5ffc7039789f8601c0ced817/dataset/60c86d19a4146301a5229e04/uploaded.bam"]
-    #Array[File] bam_array = ["/Users/eva/git/fix/test/test_test2.bam"]
-    #Array[File] bam_array = ["s3://lifebit-user-data-f0d08d30-1ff5-4d53-9128-9140f5e050ec/deploit/teams/5fc3e61799766d00247f4936/users/60c77bf4ec129e01a5a37e74/dataset/60c86d19a4146301a5229e04/test_test2.bam"]
     String gatk_docker = "broadinstitute/gatk:latest"
     String gatk_path = "/gatk/gatk"
   }


### PR DESCRIPTION
# This PR does the following:

It adds the ability for seq-format-validation workflow to be run on GEL CloudOS.

# Details:

- Hard-coded the input .bam file input

- Silenced validation error that test .bam files in the s3 lifebit-featured-datasets bucket have 

- Silenced warnings 

# Comments:

- Input of array-type variables for WDL in GEL CloudOS is still an issue (possible coercion error from js string to Array[File]) - the inputs have to be hard-coded in WDL

- The workflow would fail even though the validation report is produced - resolved by silencing errors/warnings in the validation task.

# Local testing
Successful - I downloaded the test .bam file (s3://lifebit-sars-cov-2/crg-covid/BAM/PRJNA608224_Australia_Infected.Wuhan_Hu_1_NanoPreprocess_alignment_Guppy3.1.5_Minimap2Default.minimap2.sorted.bam) and hard-coded the local path to the file inside the WDL script:
 
<img width="575" alt="Screenshot 2021-06-16 at 17 28 42" src="https://user-images.githubusercontent.com/33654687/122266103-5a18e600-ced1-11eb-8b74-8d8a16bc1aba.png">


# GEL CloudOS integration

Successful: 

<img width="1216" alt="Screenshot 2021-06-16 at 17 17 58" src="https://user-images.githubusercontent.com/33654687/122266193-77e64b00-ced1-11eb-9e94-255323f333b1.png">

N.B. To clone and reproduce the job, it is necessary to remove the empty parameter field after cloning the job by clicking the "minus" button on the right.
